### PR TITLE
fix inetnum to CIDR conversion

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -67,7 +67,7 @@ def parse_property_inetnum(block: str):
         ip_start = match[0][0]
         ip_end = match[0][1]
         cidrs = iprange_to_cidrs(ip_start, ip_end)
-        return '{}'.format(cidrs[0])
+        return cidrs
     # IPv6
     match = re.findall('^inet6num:[\s]*([0-9a-fA-F:\/]{1,43})', block, re.MULTILINE)
     if match:
@@ -167,10 +167,17 @@ def parse_blocks(jobs: Queue, connection_string: str):
         last_modified = parse_property(block, 'last-modified')
         source = parse_property(block, 'cust_source')
 
-        b = Block(inetnum=inetnum, netname=netname, description=description, country=country,
-                  maintained_by=maintained_by, created=created, last_modified=last_modified, source=source)
 
-        session.add(b)
+        if isinstance(inetnum, list):
+            for cidr in inetnum:
+                b = Block(inetnum=str(cidr), netname=netname, description=description, country=country,
+                        maintained_by=maintained_by, created=created, last_modified=last_modified, source=source)
+                session.add(b)
+        else:
+            b = Block(inetnum=inetnum, netname=netname, description=description, country=country,
+                    maintained_by=maintained_by, created=created, last_modified=last_modified, source=source)
+            session.add(b)
+
         counter += 1
         BLOCKS_DONE += 1
         if counter % COMMIT_COUNT == 0:


### PR DESCRIPTION
there is a difference of about 155k entries after applying the patch, import takes a few seconds longer(~ 2%):

before:
```
SELECT source,COUNT(*) as count FROM block GROUP BY source;
 source  |  count
---------+---------
         |   60532
 ripe    | 5261287
 afrinic |  169521
 apnic   | 1151631
 arin    |   10420
```

after:
```
SELECT source,COUNT(*) as count FROM block GROUP BY source;
 source  |  count
---------+---------
         |   60532
 ripe    | 5350081
 afrinic |  172037
 apnic   | 1215255
 arin    |   10641
```

fixes #5 