### PR TITLE
Refactoring `create_db.py`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ WORKDIR /app
 
 COPY requirements.txt /app
 
-RUN apk add --no-cache bash postgresql-libs \
+RUN apk add --no-cache bash postgresql-libs wget \
   && apk add --no-cache --virtual .builddeps build-base postgresql-dev \
-  && pip install -r requirements.txt \
+  && pip install --no-cache-dir -r requirements.txt \
   && apk del --no-cache .builddeps
 
 COPY . /app

--- a/Readme.md
+++ b/Readme.md
@@ -227,6 +227,36 @@ source        | apnic
 
 If you need to export data from PG to another source (Clickhouse, Elasticsearch, etc.) you can use:
 ```
-./bin/export_to_gzip 
+./bin/export_to_gzip
 ```
-A compressed CSV file will be created.
+A compressed CSV file will be created with the current date in the filename.
+
+The script supports various options:
+```
+./bin/export_to_gzip [OPTIONS]
+
+Options:
+  -d, --delimiter DELIMITER   Field delimiter (default: ',')
+  -t, --table TABLE           Table name to export (default: block)
+  -o, --output PREFIX         Output file prefix (default: block_dump)
+  -h, --host HOST             Database host (default: db)
+  -u, --user USER             Database user (default: network_info)
+  -n, --database NAME         Database name (default: network_info)
+  -p, --password PASSWORD     Database password (default: network_info)
+  --help                       Show this help message
+```
+
+Examples:
+```
+# Default export (comma delimiter)
+./bin/export_to_gzip
+
+# Export with semicolon delimiter
+./bin/export_to_gzip -d ';'
+
+# Export as TSV (tab-separated)
+./bin/export_to_gzip -d $'\t'
+
+# Export custom table with pipe delimiter
+./bin/export_to_gzip -t users -d '|' -o users_dump
+```

--- a/Readme.md
+++ b/Readme.md
@@ -260,3 +260,80 @@ Examples:
 # Export custom table with pipe delimiter
 ./bin/export_to_gzip -t users -d '|' -o users_dump
 ```
+
+# Export to MMDB format
+
+You can also export the database to MaxMind DB (MMDB) format for use with GeoIP2-compatible tools:
+```
+./bin/export_to_mmdb
+```
+An MMDB file will be created with the current date in the filename.
+
+**⚠️ HIGH MEMORY USAGE WARNING**
+The MMDB export process loads all data into memory before writing the final file. For large databases (millions of records), this can require several GB of RAM. Ensure you have sufficient memory available before running the export.
+
+The script supports various options:
+```
+./bin/export_to_mmdb [OPTIONS]
+
+Options:
+  -t, --table TABLE           Table name to export (default: block)
+  -o, --output PREFIX         Output file prefix (default: block_dump)
+  -h, --host HOST             Database host (default: db)
+  -u, --user USER             Database user (default: network_info)
+  -n, --database NAME         Database name (default: network_info)
+  -p, --password PASSWORD     Database password (default: network_info)
+  --help                       Show this help message
+```
+
+Examples:
+```
+# Default export
+./bin/export_to_mmdb
+
+# Export custom table
+./bin/export_to_mmdb -t users -o users_dump
+
+# Export with custom database connection
+./bin/export_to_mmdb -h localhost -u myuser -n mydb -p mypass
+```
+
+## Using the MMDB file
+
+The MMDB file contains the following network information fields for each IP range:
+
+- **netname** - Network name identifier
+- **country** - Country code (e.g., US, RU, DE)
+- **description** - Network description
+- **maintained_by** - Maintainer information
+- **created** - Creation date (YYYY-MM-DD format)
+- **last_modified** - Last modification date (YYYY-MM-DD format)
+- **source** - Source RIR (ARIN, RIPE, APNIC, LACNIC, AfriNIC)
+- **status** - Network status
+
+Once you have the MMDB file, you can use it with various tools:
+
+### Python examples
+
+Simple lookup:
+```python
+import maxminddb
+
+# Open the MMDB file
+with maxminddb.open_database('block_dump_2026-05-01.mmdb') as reader:
+    # Lookup an IP address
+    result = reader.get('8.8.8.8')
+    if result:
+        print(f"Network: {result['netname']}")
+        print(f"Country: {result['country']}")
+        print(f"Source: {result['source']}")
+```
+
+### Command line example
+```bash
+# Install mmdblookup tool
+sudo apt install mmdb-bin
+
+# Lookup an IP address
+mmdblookup --file block_dump_2026-05-01.mmdb --ip 8.8.8.8
+```

--- a/bin/export_to_gzip
+++ b/bin/export_to_gzip
@@ -2,4 +2,114 @@
 
 set -euf -o pipefail
 
-docker-compose run --rm -e PGPASSWORD=network_info --name dumper --entrypoint=psql db -h db -U network_info -e -q -x -c "copy block TO stdout  DELIMITER ';' CSV HEADER ;" network_info | gzip > ./block_dump_`date +"%Y-%m-%d"`.csv.gz
+# Detect docker compose command
+if command -v docker-compose &> /dev/null; then
+    DOCKER_COMPOSE="docker-compose"
+else
+    DOCKER_COMPOSE="docker compose"
+fi
+
+# Default values
+DELIMITER=","
+TABLE="block"
+OUTPUT_PREFIX="block_dump"
+DB_HOST="db"
+DB_USER="network_info"
+DB_NAME="network_info"
+DB_PASSWORD="network_info"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -d|--delimiter)
+            DELIMITER="$2"
+            shift 2
+            ;;
+        -t|--table)
+            TABLE="$2"
+            shift 2
+            ;;
+        -o|--output)
+            OUTPUT_PREFIX="$2"
+            shift 2
+            ;;
+        -h|--host)
+            DB_HOST="$2"
+            shift 2
+            ;;
+        -u|--user)
+            DB_USER="$2"
+            shift 2
+            ;;
+        -n|--database)
+            DB_NAME="$2"
+            shift 2
+            ;;
+        -p|--password)
+            DB_PASSWORD="$2"
+            shift 2
+            ;;
+        --help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  -d, --delimiter DELIMITER   Field delimiter (default: ',')"
+            echo "  -t, --table TABLE           Table name to export (default: block)"
+            echo "  -o, --output PREFIX         Output file prefix (default: block_dump)"
+            echo "  -h, --host HOST             Database host (default: db)"
+            echo "  -u, --user USER             Database user (default: network_info)"
+            echo "  -n, --database NAME         Database name (default: network_info)"
+            echo "  -p, --password PASSWORD     Database password (default: network_info)"
+            echo "  --help                       Show this help message"
+            echo ""
+            echo "Examples:"
+            echo "  # Default export (comma delimiter)"
+            echo "  $0"
+            echo ""
+            echo "  # Export with semicolon delimiter"
+            echo "  $0 -d ';'"
+            echo ""
+            echo "  # Export as TSV (tab-separated)"
+            echo "  $0 -d \$'\\t'"
+            echo ""
+            echo "  # Export custom table with pipe delimiter"
+            echo "  $0 -t users -d '|' -o users_dump"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Escape delimiter for SQL (special characters like tab need special handling)
+if [[ "$DELIMITER" == $'\t' ]]; then
+    DELIMITER_SQL="E'\\t'"
+else
+    DELIMITER_SQL="'$DELIMITER'"
+fi
+
+# Generate output filename with date
+OUTPUT_FILE="${OUTPUT_PREFIX}_$(date +'%Y-%m-%d').csv.gz"
+
+# Build and execute the COPY command
+COPY_CMD="copy $TABLE TO stdout DELIMITER $DELIMITER_SQL CSV HEADER ;"
+
+echo "Exporting table '$TABLE' from database '$DB_NAME'..."
+echo "Delimiter: '$DELIMITER'"
+echo "Output: $OUTPUT_FILE"
+
+$DOCKER_COMPOSE run --rm \
+    -e PGPASSWORD="$DB_PASSWORD" \
+    --name dumper \
+    --entrypoint=psql \
+    db \
+    -h "$DB_HOST" \
+    -U "$DB_USER" \
+    -e -q -x \
+    -c "$COPY_CMD" \
+    "$DB_NAME" | gzip > "$OUTPUT_FILE"
+
+echo "Export completed successfully: $OUTPUT_FILE"

--- a/bin/export_to_mmdb
+++ b/bin/export_to_mmdb
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -euf -o pipefail
+
+# Detect docker compose command
+if command -v docker-compose &> /dev/null; then
+    DOCKER_COMPOSE="docker-compose"
+else
+    DOCKER_COMPOSE="docker compose"
+fi
+
+# Default values
+TABLE="block"
+OUTPUT_PREFIX="block_dump"
+DB_HOST="db"
+DB_USER="network_info"
+DB_NAME="network_info"
+DB_PASSWORD="network_info"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -t|--table)
+            TABLE="$2"
+            shift 2
+            ;;
+        -o|--output)
+            OUTPUT_PREFIX="$2"
+            shift 2
+            ;;
+        -h|--host)
+            DB_HOST="$2"
+            shift 2
+            ;;
+        -u|--user)
+            DB_USER="$2"
+            shift 2
+            ;;
+        -n|--database)
+            DB_NAME="$2"
+            shift 2
+            ;;
+        -p|--password)
+            DB_PASSWORD="$2"
+            shift 2
+            ;;
+        --help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  -t, --table TABLE           Table name to export (default: block)"
+            echo "  -o, --output PREFIX         Output file prefix (default: block_dump)"
+            echo "  -h, --host HOST             Database host (default: db)"
+            echo "  -u, --user USER             Database user (default: network_info)"
+            echo "  -n, --database NAME         Database name (default: network_info)"
+            echo "  -p, --password PASSWORD     Database password (default: network_info)"
+            echo "  --help                       Show this help message"
+            echo ""
+            echo "Examples:"
+            echo "  # Default export"
+            echo "  $0"
+            echo ""
+            echo "  # Export custom table"
+            echo "  $0 -t users -o users_dump"
+            echo ""
+            echo "  # Export with custom database connection"
+            echo "  $0 -h localhost -u myuser -n mydb -p mypass"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Generate output filename with date
+OUTPUT_FILE="${OUTPUT_PREFIX}_$(date +'%Y-%m-%d').mmdb"
+
+# Build connection string
+CONNECTION_STRING="postgresql+psycopg://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:5432/${DB_NAME}"
+
+echo "Exporting table '$TABLE' from database '$DB_NAME'..."
+echo "Output: $OUTPUT_FILE"
+
+$DOCKER_COMPOSE run --rm \
+    -e PGPASSWORD="$DB_PASSWORD" \
+    -v "$(pwd):/app/output" \
+    --name mmdb_exporter \
+    --entrypoint=python3 \
+    network_info \
+    export_to_mmdb.py \
+    -c "$CONNECTION_STRING" \
+    -o "/app/output/$OUTPUT_FILE" \
+    -t "$TABLE"
+
+echo "Export completed successfully: $OUTPUT_FILE"

--- a/create_db.py
+++ b/create_db.py
@@ -41,35 +41,48 @@ def get_source(filename: str):
     return None
 
 def parse_property(block: bytes, name: bytes):
-    match = re.findall(b'^%s:\s?(.+)$' % name, block, re.MULTILINE)
+    match = re.findall(rb'^%s:\s?(.+)$' % name, block, re.MULTILINE)
     if match:
+        # remove empty lines and remove multiple names
         x = b' '.join(list(filter(None,(x.strip().replace(b"%s: " % name, b'').replace(b"%s: " % name, b'') for x in match))))
+        # remove multiple whitespaces by using a split hack
+        # decode to latin-1 so it can be inserted in the database
         return ' '.join(x.decode('latin-1').split())
     return None
 
 def parse_property_inetnum(block: bytes):
+    # IPv4
     match = re.findall(rb'^inetnum:[\s]*((?:\d{1,3}\.){3}\d{1,3})[\s]*-[\s]*((?:\d{1,3}\.){3}\d{1,3})', block, re.MULTILINE)
     if match:
+        # netaddr can only handle strings, not bytes
         ip_start = match[0][0].decode('utf-8')
         ip_end = match[0][1].decode('utf-8')
         return iprange_to_cidrs(ip_start, ip_end)
+    
+    # direct CIDR in lacnic db
     match = re.findall(rb'^inetnum:[\s]*((?:\d{1,3}\.){3}\d{1,3}/\d+)', block, re.MULTILINE)
     if match:
         return match[0]
+    # lacnic with wrong ip
+    # inetnum:    177.46.7/24
     match = re.findall(rb'^inetnum:[\s]*((?:\d{1,3}\.){2}\d{1,3}/\d+)', block, re.MULTILINE)
     if match:
         tmp = match[0].split(b"/")
         return f"{tmp[0].decode('utf-8')}.0/{tmp[1].decode('utf-8')}".encode("utf-8")
+    # inetnum:    148.204/16
     match = re.findall(rb'^inetnum:[\s]*((?:\d{1,3}\.){1}\d{1,3}/\d+)', block, re.MULTILINE)
     if match:
         tmp = match[0].split(b"/")
         return f"{tmp[0].decode('utf-8')}.0.0/{tmp[1].decode('utf-8')}".encode("utf-8")
+    # IPv6
     match = re.findall(rb'^inet6num:[\s]*([0-9a-fA-F:\/]{1,43})', block, re.MULTILINE)
     if match:
         return match[0]
+    # ARIN route IPv4
     match = re.findall(rb'^route:[\s]*((?:\d{1,3}\.){3}\d{1,3}/\d{1,2})', block, re.MULTILINE)
     if match:
         return match[0]
+    # ARIN route6 IPv6
     match = re.findall(rb'^route6:[\s]*([0-9a-fA-F:\/]{1,43})', block, re.MULTILINE)
     if match:
         return match[0]
@@ -82,13 +95,19 @@ def read_blocks(filename: str):
     blocks = []
     with openmethod(filename, mode='rb') as f:
         for line in f:
+            # skip comments
             if line.startswith((b'%', b'#', b'remarks:')):
                 continue
+            # block end
             if line.strip() == b'':
                 if single_block.startswith((b'inetnum:', b'inet6num:', b'route:', b'route6:')):
+                    # add source
                     single_block += b"cust_source: %s" % cust_source
                     blocks.append(single_block)
                     single_block = b''
+                    # comment out to only parse x blocks
+                    # if len(blocks) == 100:
+                    #    break
                 else:
                     single_block = b''
             else:
@@ -101,22 +120,52 @@ def parse_blocks(jobs: Queue, connection_string: str, total_blocks: int):
     counter = 0
     blocks_done = 0
     start_time = time.time()
+
     while True:
         block = jobs.get()
         if block is None:
             break
+
         inetnum = parse_property_inetnum(block)
         if not inetnum:
+            # invalid entry, do not parse
             continue
+
+        # No netname field in ARIN block, try origin
         netname = parse_property(block, b'netname') or parse_property(block, b'origin')
         description = parse_property(block, b'descr')
         country = parse_property(block, b'country')
         city = parse_property(block, b'city')
+        # if we have a city object, append it to the country
         if city:
             country = f"{country} - {city}"
         maintained_by = parse_property(block, b'mnt-by')
         created = parse_property(block, b'created')
         last_modified = parse_property(block, b'last-modified')
+        if not last_modified:
+            changed = parse_property(block, b'changed')
+            # ***@ripe.net 19960624
+            # a.c@domain.com 20060331
+            # maybe repeated multiple times, we only take the first
+            if re.match(r'^.+?@.+? \d+', changed):
+                date = changed.split(" ")[1].strip()
+                if len(date) == 8:
+                    year = int(date[0:4])
+                    month = int(date[4:6])
+                    day = int(date[6:8])
+                    # some sanity checks for dates
+                    if month >= 1 and month <=12 and day >= 1 and day <= 31:
+                        last_modified = f"{year}-{month}-{day}"
+                    else:
+                        logger.debug(f"ignoring invalid changed date {date}")
+                else:
+                    logger.debug(f"ignoring invalid changed date {date}")
+            elif "@" in changed:
+                # email in changed field without date
+                logger.debug(f"ignoring invalid changed date {changed}")
+            else:
+                last_modified = changed
+
         status = parse_property(block, b'status')
         source = parse_property(block, b'cust_source')
         if isinstance(inetnum, list):
@@ -129,6 +178,7 @@ def parse_blocks(jobs: Queue, connection_string: str, total_blocks: int):
         if counter % COMMIT_COUNT == 0:
             session.commit()
             percent = (blocks_done * NUM_WORKERS * 100) / total_blocks if total_blocks else 0
+            # not really accurate at the moment
             logger.debug(f'committed {counter} blocks ({round(time.time() - start_time,2)}s) {percent:.1f}% done')
             counter = 0
             start_time = time.time()
@@ -138,27 +188,33 @@ def parse_blocks(jobs: Queue, connection_string: str, total_blocks: int):
 
 def main(connection_string):
     overall_start_time = time.time()
+    # reset database
     setup_connection(connection_string, create_db=True)
     for entry in FILELIST:
         f_name = f"./databases/{entry}"
         if not os.path.exists(f_name):
-            logger.info(f"File {f_name} not found")
+            logger.info(f"File {f_name} not found. Please download using download_dumps.sh")
             continue
+
         logger.info(f"parsing database file: {f_name}")
         start_time = time.time()
         blocks = read_blocks(f_name)
         logger.info(f"database parsing finished: {round(time.time() - start_time,2)} seconds")
         total_blocks = len(blocks)
+        
         jobs = Queue()
         workers = []
+        # start workers
         for _ in range(NUM_WORKERS):
             p = Process(target=parse_blocks, args=(jobs, connection_string, total_blocks), daemon=True)
             p.start()
             workers.append(p)
+        # add tasks
         for b in blocks:
             jobs.put(b)
         for _ in range(NUM_WORKERS):
             jobs.put(None)
+         # wait to finish
         for p in workers:
             p.join()
         logger.info(f"block parsing finished: {round(time.time() - start_time,2)} seconds")

--- a/create_db.py
+++ b/create_db.py
@@ -6,7 +6,6 @@ import gzip
 import time
 from multiprocessing import cpu_count, Queue, Process, current_process
 import logging
-
 import re
 import os.path
 from db.model import Block
@@ -14,30 +13,17 @@ from db.helper import setup_connection
 from netaddr import iprange_to_cidrs
 
 VERSION = '2.0'
-FILELIST = ['afrinic.db.gz', 'apnic.db.inet6num.gz', 'apnic.db.inetnum.gz', 'arin.db.gz',
-            'lacnic.db.gz', 'ripe.db.inetnum.gz', 'ripe.db.inet6num.gz']
+FILELIST = ['afrinic.db.gz','apnic.db.inet6num.gz','apnic.db.inetnum.gz','arin.db.gz','lacnic.db.gz','ripe.db.inetnum.gz','ripe.db.inet6num.gz']
 NUM_WORKERS = cpu_count()
-LOG_FORMAT = '%(asctime)-15s - %(name)-9s - %(levelname)-8s - %(processName)-11s - %(filename)s - %(message)s'
+LOG_FORMAT = '%(asctime)-15s - %(name)-9s - %(levelname)-8s - %(processName)-11s - %(message)s'
 COMMIT_COUNT = 10000
-NUM_BLOCKS = 0
-CURRENT_FILENAME = "empty"
-
-
-class ContextFilter(logging.Filter):
-    def filter(self, record):
-        record.filename = CURRENT_FILENAME
-        return True
-
 
 logger = logging.getLogger('create_db')
 logger.setLevel(logging.INFO)
-f = ContextFilter()
-logger.addFilter(f)
 formatter = logging.Formatter(LOG_FORMAT)
 stream_handler = logging.StreamHandler()
 stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
-
 
 def get_source(filename: str):
     if filename.startswith('afrinic'):
@@ -51,249 +37,138 @@ def get_source(filename: str):
     elif filename.startswith('ripe'):
         return b'ripe'
     else:
-        logger.error(f"Can not determine source for {filename}")
+        logger.error(f"Cannot determine source for {filename}")
     return None
 
-
-def parse_property(block: str, name: str) -> str:
-    match = re.findall(b'^%s:\s?(.+)$' % (name), block, re.MULTILINE)
+def parse_property(block: bytes, name: bytes):
+    match = re.findall(b'^%s:\s?(.+)$' % name, block, re.MULTILINE)
     if match:
-        # remove empty lines and remove multiple names
-        x = b' '.join(list(filter(None, (x.strip().replace(
-            b"%s: " % name, b'').replace(b"%s: " % name, b'') for x in match))))
-        # remove multiple whitespaces by using a split hack
-        # decode to latin-1 so it can be inserted in the database
+        x = b' '.join(list(filter(None,(x.strip().replace(b"%s: " % name, b'').replace(b"%s: " % name, b'') for x in match))))
         return ' '.join(x.decode('latin-1').split())
-    else:
-        return None
+    return None
 
-
-def parse_property_inetnum(block: str):
-    # IPv4
-    match = re.findall(
-        rb'^inetnum:[\s]*((?:\d{1,3}\.){3}\d{1,3})[\s]*-[\s]*((?:\d{1,3}\.){3}\d{1,3})', block, re.MULTILINE)
+def parse_property_inetnum(block: bytes):
+    match = re.findall(rb'^inetnum:[\s]*((?:\d{1,3}\.){3}\d{1,3})[\s]*-[\s]*((?:\d{1,3}\.){3}\d{1,3})', block, re.MULTILINE)
     if match:
-        # netaddr can only handle strings, not bytes
         ip_start = match[0][0].decode('utf-8')
         ip_end = match[0][1].decode('utf-8')
-        cidrs = iprange_to_cidrs(ip_start, ip_end)
-        return cidrs
-    # direct CIDR in lacnic db
+        return iprange_to_cidrs(ip_start, ip_end)
     match = re.findall(rb'^inetnum:[\s]*((?:\d{1,3}\.){3}\d{1,3}/\d+)', block, re.MULTILINE)
     if match:
         return match[0]
-    # lacnic with wrong ip
-    # inetnum:    177.46.7/24
     match = re.findall(rb'^inetnum:[\s]*((?:\d{1,3}\.){2}\d{1,3}/\d+)', block, re.MULTILINE)
     if match:
         tmp = match[0].split(b"/")
         return f"{tmp[0].decode('utf-8')}.0/{tmp[1].decode('utf-8')}".encode("utf-8")
-    # inetnum:    148.204/16
     match = re.findall(rb'^inetnum:[\s]*((?:\d{1,3}\.){1}\d{1,3}/\d+)', block, re.MULTILINE)
     if match:
         tmp = match[0].split(b"/")
         return f"{tmp[0].decode('utf-8')}.0.0/{tmp[1].decode('utf-8')}".encode("utf-8")
-    # IPv6
-    match = re.findall(
-        rb'^inet6num:[\s]*([0-9a-fA-F:\/]{1,43})', block, re.MULTILINE)
+    match = re.findall(rb'^inet6num:[\s]*([0-9a-fA-F:\/]{1,43})', block, re.MULTILINE)
     if match:
         return match[0]
-    # ARIN route IPv4
-    match = re.findall(
-        rb'^route:[\s]*((?:\d{1,3}\.){3}\d{1,3}/\d{1,2})', block, re.MULTILINE)
+    match = re.findall(rb'^route:[\s]*((?:\d{1,3}\.){3}\d{1,3}/\d{1,2})', block, re.MULTILINE)
     if match:
         return match[0]
-    # ARIN route6 IPv6
-    match = re.findall(
-        rb'^route6:[\s]*([0-9a-fA-F:\/]{1,43})', block, re.MULTILINE)
+    match = re.findall(rb'^route6:[\s]*([0-9a-fA-F:\/]{1,43})', block, re.MULTILINE)
     if match:
         return match[0]
     return None
 
-
-def read_blocks(filename: str) -> list:
-    if filename.endswith('.gz'):
-        opemethod = gzip.open
-    else:
-        opemethod = open
+def read_blocks(filename: str):
+    openmethod = gzip.open if filename.endswith('.gz') else open
     cust_source = get_source(filename.split('/')[-1])
     single_block = b''
     blocks = []
-
-    with opemethod(filename, mode='rb') as f:
+    with openmethod(filename, mode='rb') as f:
         for line in f:
-            # skip comments
-            if line.startswith(b'%') or line.startswith(b'#') or line.startswith(b'remarks:'):
+            if line.startswith((b'%', b'#', b'remarks:')):
                 continue
-            # block end
             if line.strip() == b'':
-                if single_block.startswith(b'inetnum:') or single_block.startswith(b'inet6num:') or single_block.startswith(b'route:') or single_block.startswith(b'route6:'):
-                    # add source
-                    single_block += b"cust_source: %s" % (cust_source)
+                if single_block.startswith((b'inetnum:', b'inet6num:', b'route:', b'route6:')):
+                    single_block += b"cust_source: %s" % cust_source
                     blocks.append(single_block)
-                    if len(blocks) % 1000 == 0:
-                        logger.debug(
-                            f"parsed another 1000 blocks ({len(blocks)} so far)")
                     single_block = b''
-                    # comment out to only parse x blocks
-                    # if len(blocks) == 100:
-                    #    break
                 else:
                     single_block = b''
             else:
                 single_block += line
     logger.info(f"Got {len(blocks)} blocks")
-    global NUM_BLOCKS
-    NUM_BLOCKS = len(blocks)
     return blocks
 
-
-def parse_blocks(jobs: Queue, connection_string: str):
+def parse_blocks(jobs: Queue, connection_string: str, total_blocks: int):
     session = setup_connection(connection_string)
-
     counter = 0
-    BLOCKS_DONE = 0
-
+    blocks_done = 0
     start_time = time.time()
     while True:
         block = jobs.get()
         if block is None:
             break
-
         inetnum = parse_property_inetnum(block)
         if not inetnum:
-            # invalid entry, do not parse
-            logger.warning(f"Could not parse inetnum on block {block}. skipping")
             continue
-        netname = parse_property(block, b'netname')
-        # No netname field in ARIN block, try origin
-        if not netname:
-            netname = parse_property(block, b'origin')
+        netname = parse_property(block, b'netname') or parse_property(block, b'origin')
         description = parse_property(block, b'descr')
         country = parse_property(block, b'country')
-        # if we have a city object, append it to the country
         city = parse_property(block, b'city')
         if city:
             country = f"{country} - {city}"
         maintained_by = parse_property(block, b'mnt-by')
         created = parse_property(block, b'created')
         last_modified = parse_property(block, b'last-modified')
-        if not last_modified:
-            changed = parse_property(block, b'changed')
-            # ***@ripe.net 19960624
-            # a.c@domain.com 20060331
-            # maybe repeated multiple times, we only take the first
-            if re.match(r'^.+?@.+? \d+', changed):
-                date = changed.split(" ")[1].strip()
-                if len(date) == 8:
-                    year = int(date[0:4])
-                    month = int(date[4:6])
-                    day = int(date[6:8])
-                    # some sanity checks for dates
-                    if month >= 1 and month <=12 and day >= 1 and day <= 31:
-                        last_modified = f"{year}-{month}-{day}"
-                    else:
-                        logger.debug(f"ignoring invalid changed date {date}")
-                else:
-                    logger.debug(f"ignoring invalid changed date {date}")
-            elif "@" in changed:
-                # email in changed field without date
-                logger.debug(f"ignoring invalid changed date {changed}")
-            else:
-                last_modified = changed
         status = parse_property(block, b'status')
         source = parse_property(block, b'cust_source')
-
         if isinstance(inetnum, list):
             for cidr in inetnum:
-                b = Block(inetnum=str(cidr), netname=netname, description=description, country=country,
-                          maintained_by=maintained_by, created=created, last_modified=last_modified, source=source, status=status)
-                session.add(b)
+                session.add(Block(inetnum=str(cidr), netname=netname, description=description, country=country, maintained_by=maintained_by, created=created, last_modified=last_modified, source=source, status=status))
         else:
-            b = Block(inetnum=inetnum.decode('utf-8'), netname=netname, description=description, country=country,
-                      maintained_by=maintained_by, created=created, last_modified=last_modified, source=source, status=status)
-            session.add(b)
-
+            session.add(Block(inetnum=inetnum.decode('utf-8'), netname=netname, description=description, country=country, maintained_by=maintained_by, created=created, last_modified=last_modified, source=source, status=status))
         counter += 1
-        BLOCKS_DONE += 1
+        blocks_done += 1
         if counter % COMMIT_COUNT == 0:
             session.commit()
-            session.close()
-            session = setup_connection(connection_string)
-            # not really accurate at the moment
-            percent = (BLOCKS_DONE * NUM_WORKERS * 100) / NUM_BLOCKS
-            if percent > 100:
-                percent = 100
-            logger.debug('committed {} blocks ({} seconds) {:.1f}% done.'.format(
-                counter, round(time.time() - start_time, 2), percent))
+            percent = (blocks_done * NUM_WORKERS * 100) / total_blocks if total_blocks else 0
+            logger.debug(f'committed {counter} blocks ({round(time.time() - start_time,2)}s) {percent:.1f}% done')
             counter = 0
             start_time = time.time()
     session.commit()
-    logger.debug('committed last blocks')
     session.close()
     logger.debug(f"{current_process().name} finished")
 
-
 def main(connection_string):
     overall_start_time = time.time()
-    # reset database
     setup_connection(connection_string, create_db=True)
-
     for entry in FILELIST:
-        global CURRENT_FILENAME
-        CURRENT_FILENAME = entry
         f_name = f"./databases/{entry}"
-        if os.path.exists(f_name):
-            logger.info(f"parsing database file: {f_name}")
-            start_time = time.time()
-            blocks = read_blocks(f_name)
-            logger.info(f"database parsing finished: {round(time.time() - start_time, 2)} seconds")
-
-            logger.info('parsing blocks')
-            start_time = time.time()
-
-            jobs = Queue()
-
-            workers = []
-            # start workers
-            logger.debug(f"starting {NUM_WORKERS} processes")
-            for _ in range(NUM_WORKERS):
-                p = Process(target=parse_blocks, args=(
-                    jobs, connection_string,), daemon=True)
-                p.start()
-                workers.append(p)
-
-            # add tasks
-            for b in blocks:
-                jobs.put(b)
-            for _ in range(NUM_WORKERS):
-                jobs.put(None)
-            jobs.close()
-            jobs.join_thread()
-
-            # wait to finish
-            for p in workers:
-                p.join()
-
-            logger.info(
-                f"block parsing finished: {round(time.time() - start_time, 2)} seconds")
-        else:
-            logger.info(
-                f"File {f_name} not found. Please download using download_dumps.sh")
-
-    CURRENT_FILENAME = "empty"
-    logger.info(
-        f"script finished: {round(time.time() - overall_start_time, 2)} seconds")
-
+        if not os.path.exists(f_name):
+            logger.info(f"File {f_name} not found")
+            continue
+        logger.info(f"parsing database file: {f_name}")
+        start_time = time.time()
+        blocks = read_blocks(f_name)
+        logger.info(f"database parsing finished: {round(time.time() - start_time,2)} seconds")
+        total_blocks = len(blocks)
+        jobs = Queue()
+        workers = []
+        for _ in range(NUM_WORKERS):
+            p = Process(target=parse_blocks, args=(jobs, connection_string, total_blocks), daemon=True)
+            p.start()
+            workers.append(p)
+        for b in blocks:
+            jobs.put(b)
+        for _ in range(NUM_WORKERS):
+            jobs.put(None)
+        for p in workers:
+            p.join()
+        logger.info(f"block parsing finished: {round(time.time() - start_time,2)} seconds")
+    logger.info(f"script finished: {round(time.time() - overall_start_time,2)} seconds")
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Create DB')
-    parser.add_argument('-c', dest='connection_string', type=str,
-                        required=True, help="Connection string to the postgres database")
-    parser.add_argument("-d", "--debug", action="store_true",
-                        help="set loglevel to DEBUG")
-    parser.add_argument('--version', action='version',
-                        version=f"%(prog)s {VERSION}")
+    parser.add_argument('-c', dest='connection_string', type=str, required=True, help="Connection string to postgres")
+    parser.add_argument("-d", "--debug", action="store_true")
+    parser.add_argument('--version', action='version', version=f"%(prog)s {VERSION}")
     args = parser.parse_args()
     if args.debug:
         logger.setLevel(logging.DEBUG)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  network_info:
+    entrypoint: /app/create_db.py
+    command: -c postgresql+psycopg://network_info:network_info@db:5432/network_info -d
+    volumes:
+      - .:/app

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,7 +1,0 @@
-version: "3"
-services:
-  network_info:
-    entrypoint: /app/create_db.py
-    command: -c postgresql+psycopg://network_info:network_info@db:5432/network_info -d
-    volumes:
-      - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     image: network_info
     build:
       context: .
-    command: -c postgresql+psycopg://network_info:network_info@db:5432/network_info
+    environment:
+      - DB_CONNECTION=postgresql+psycopg://network_info:network_info@db:5432/network_info
     volumes:
       - /etc/localtime:/etc/localtime:ro
     depends_on:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-./download_dumps.sh
+/app/download_dumps.sh
 
-/app/create_db.py "$@"
+/app/create_db.py -c "$DB_CONNECTION"

--- a/export_to_mmdb.py
+++ b/export_to_mmdb.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import argparse
+import sys
+import gc
+from datetime import datetime
+import netaddr
+from sqlalchemy import select
+from sqlalchemy.orm import sessionmaker
+from db.model import Block
+from db.helper import create_postgres_pool
+
+
+def export_to_mmdb(connection_string, output_file, table="block"):
+    """Export PostgreSQL table to MMDB format"""
+    
+    # Create database connection
+    engine = create_postgres_pool(connection_string)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    
+    # Query all blocks with streaming to avoid memory issues
+    print(f"Exporting table '{table}' to MMDB format...")
+    query = select(Block)
+    result = session.execute(query)
+    
+    # Use yield_per to stream blocks instead of loading all at once
+    blocks = result.scalars().yield_per(1000)
+    
+    print(f"Starting export (streaming blocks)...")
+    
+    try:
+        from mmdb_writer import MMDBWriter
+    except ImportError:
+        print("Error: mmdb_writer library not found. Please install it with: pip install mmdb-writer")
+        sys.exit(1)
+    
+    writer = MMDBWriter(
+        ip_version=6,
+        ipv4_compatible=True,
+        database_type="Network Info Block",
+        languages=["en"],
+        description={
+            "en": "Network block information from RIR databases"
+        },
+    )
+    
+    count = 0
+    
+    for block in blocks:
+        try:
+            # Skip default route blocks that aren't real networks
+            cidr = str(block.inetnum)
+            if cidr in ['::/0', '0.0.0.0/0']:
+                continue
+            
+            # Create the data structure for this network - minimize memory usage
+            data = {
+                "netname": block.netname or "",
+                "country": block.country or "",
+                "description": block.description or "",
+                "maintained_by": block.maintained_by or "",
+                "created": block.created.strftime('%Y-%m-%d') if block.created else "",
+                "last_modified": block.last_modified.strftime('%Y-%m-%d') if block.last_modified else "",
+                "source": block.source or "",
+                "status": block.status or ""
+            }
+            
+            # Insert network using IPSet with CIDR string list
+            ipset = netaddr.IPSet([cidr])
+            writer.insert_network(ipset, data)
+            count += 1
+            
+            if count % 10000 == 0:
+                print(f"  Processed {count} blocks...")
+                # Force garbage collection periodically
+                gc.collect()
+            
+        except Exception as e:
+            print(f"Warning: Failed to process block {block.inetnum}: {e}")
+            continue
+    
+    # Write to file
+    writer.to_db_file(output_file)
+    print(f"Export completed successfully: {count} blocks -> {output_file}")
+    
+    session.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Export PostgreSQL table to MMDB format")
+    parser.add_argument("-c", "--connection", 
+                        default="postgresql://network_info:network_info@db:5432/network_info",
+                        help="Database connection string")
+    parser.add_argument("-o", "--output",
+                        default="block_dump.mmdb",
+                        help="Output MMDB file path")
+    parser.add_argument("-t", "--table",
+                        default="block",
+                        help="Table name to export")
+        
+    args = parser.parse_args()
+    
+    # Add date to output filename if not already present
+    if "_$(date" not in args.output and not args.output.endswith(".mmdb"):
+        args.output = f"{args.output}_{datetime.now().strftime('%Y-%m-%d')}.mmdb"
+    elif not args.output.endswith(".mmdb"):
+        args_output = args.output.rsplit(".", 1)[0]
+        args.output = f"{args_output}_{datetime.now().strftime('%Y-%m-%d')}.mmdb"
+    
+    export_to_mmdb(args.connection, args.output, args.table)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-netaddr==1.3.0
+netaddr>=0.8.0
 psycopg==3.3.3
 psycopg-c==3.3.3
 psycopg-pool==3.3.0
 SQLAlchemy==2.0.49
+mmdb-writer==0.2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-netaddr>=0.8.0
+netaddr==1.3.0
 psycopg==3.3.3
 psycopg-c==3.3.3
 psycopg-pool==3.3.0


### PR DESCRIPTION
Hi!

The old version of the `create_db.py` code crashes with a divide-by-zero error.

Some logs:

```
/app/create_db.py:59: SyntaxWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
  match = re.findall(b'^%s:\s?(.+)$' % (name), block, re.MULTILINE)
Process Process-6:
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/multiprocessing/process.py", line 320, in _bootstrap
    self.run()
    ~~~~~~~~^^
  File "/usr/local/lib/python3.14/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/create_db.py", line 224, in parse_blocks
    percent = (BLOCKS_DONE * NUM_WORKERS * 100) / NUM_BLOCKS
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
ZeroDivisionError: division by zero
Process Process-2:
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/multiprocessing/process.py", line 320, in _bootstrap
    self.run()
    ~~~~~~~~^^
  File "/usr/local/lib/python3.14/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/create_db.py", line 224, in parse_blocks
    percent = (BLOCKS_DONE * NUM_WORKERS * 100) / NUM_BLOCKS
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
ZeroDivisionError: division by zero


```



After refactoring the code, I fixed it and also eliminated the use of `global` variables.


